### PR TITLE
Arreglada dependencia en pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.uqbar-project</groupId>
-			<artifactId>seguidorCarrera-domain-xtend</artifactId>
-			<version>1.0.5-SNAPSHOT</version>
+			<artifactId>eg-seguidorCarrera-domain-xtend</artifactId>
+			<version>1.0.3</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Fallaba este ejemplo porque la dependencia al projecto de dominio estaba mal: le faltaba el "eg-" y la versión tenía otro numero que no es el que figura actualmente en el repo de dominio.

Otra cosa que noté, cuál es la convención para los pom/repos? porque veo que hay algunos que estan con guiones y otros con camelCase.